### PR TITLE
fix #47 browser hint for 'Long' module

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "author": "Daniel Wirtz <dcode@dcode.io>",
   "description": "The swiss army knife for binary data in JavaScript.",
   "main": "index.js",
-  "browser": "dist/ByteBufferAB.js",
+  "browser": {
+    "index.js": "bytebuffer/dist/ByteBufferAB.js",
+    "Long": "bytebuffer/node_modules/long/dist/Long.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/dcodeIO/ByteBuffer.js.git"


### PR DESCRIPTION
Browser hint for webpack and browserify for where to load the "Long" module.

The `"index.js": "bytebuffer/dist/ByteBufferAB.js"` line is effectively doing the same thing as the previous `"browser": "dist/ByteBufferAB.js"`. It's used in conjunction with the `main` option and is necessary since the `browser` property is overloaded.

The `Long` mapping should help avoid renaming the AMD module.