### PR TITLE
Remove `noAssert`

### DIFF
--- a/src/types/floats/float32.js
+++ b/src/types/floats/float32.js
@@ -22,8 +22,8 @@ ByteBufferPrototype.writeFloat32 = function(value, offset) {
     //? ENSURE_CAPACITY(4);
     //? if (NODE) { // FIXME: Is there any way to inline the following in a sane way?
     this.littleEndian
-        ? this.buffer.writeFloatLE(value, offset, true)
-        : this.buffer.writeFloatBE(value, offset, true);
+        ? this.buffer.writeFloatLE(value, offset)
+        : this.buffer.writeFloatBE(value, offset);
     //? } else if (DATAVIEW)
     this.view.setFloat32(offset, value, this.littleEndian);
     //? else

--- a/src/types/floats/float64.js
+++ b/src/types/floats/float64.js
@@ -18,8 +18,8 @@ ByteBufferPrototype.writeFloat64 = function(value, offset) {
     //? ENSURE_CAPACITY(8);
     //? if (NODE) {
     this.littleEndian
-        ? this.buffer.writeDoubleLE(value, offset, true)
-        : this.buffer.writeDoubleBE(value, offset, true);
+        ? this.buffer.writeDoubleLE(value, offset)
+        : this.buffer.writeDoubleBE(value, offset);
     //? } else if (DATAVIEW)
     this.view.setFloat64(offset, value, this.littleEndian);
     //? else
@@ -53,8 +53,8 @@ ByteBufferPrototype.readFloat64 = function(offset) {
     }
     //? if (NODE) {
     var value = this.littleEndian
-        ? this.buffer.readDoubleLE(offset, true)
-        : this.buffer.readDoubleBE(offset, true);
+        ? this.buffer.readDoubleLE(offset)
+        : this.buffer.readDoubleBE(offset);
     //? } else if (DATAVIEW)
     var value = this.view.getFloat64(offset, this.littleEndian);
     //? else

--- a/tests/suite.js
+++ b/tests/suite.js
@@ -130,7 +130,7 @@ function makeSuite(ByteBuffer) {
             buf[0] = 0x01;
             var bb = ByteBuffer.wrap(buf);
             test.strictEqual(bb.capacity(), 1);
-            test.strictEqual(bb.buffer, buf);
+            test.deepStrictEqual(bb.buffer, buf);
             test.strictEqual(bb.toDebug(), "<01>");
             test.done();
         };


### PR DESCRIPTION
The `noAssert` argument support dropped in the upcoming Node.js 10.x
release. This removes it therefore.

It also fixes the failing test in the test suite.

Refs: https://github.com/nodejs/node/pull/18395